### PR TITLE
Address Phase 1-2 evaluation concerns: deduplication, concurrency, an…

### DIFF
--- a/src/MessageQueue.Core/CircularBuffer.cs
+++ b/src/MessageQueue.Core/CircularBuffer.cs
@@ -184,7 +184,7 @@ public class CircularBuffer : ICircularBuffer
 
             if (existing != null &&
                 existing.DeduplicationKey == deduplicationKey &&
-                existing.Status == MessageStatus.InFlight)
+                (existing.Status == MessageStatus.InFlight || existing.Status == MessageStatus.Ready))
             {
                 // Mark existing as superseded
                 var superseded = new MessageEnvelope
@@ -213,7 +213,7 @@ public class CircularBuffer : ICircularBuffer
             }
         }
 
-        // No in-flight message found with this key
+        // No message found with this key in Ready or InFlight state
         return Task.FromResult(false);
     }
 

--- a/src/MessageQueue.Core/QueueManager.cs
+++ b/src/MessageQueue.Core/QueueManager.cs
@@ -116,7 +116,7 @@ public class QueueManager : IQueueManager
         if (string.IsNullOrWhiteSpace(handlerId))
             throw new ArgumentException("Handler ID cannot be null or whitespace.", nameof(handlerId));
 
-        var lease = leaseDuration ?? _options.DefaultTimeout;
+        var lease = leaseDuration == default(TimeSpan) ? _options.DefaultTimeout : leaseDuration;
         var messageType = typeof(T);
 
         var envelope = await _buffer.CheckoutAsync(messageType, handlerId, lease, cancellationToken);
@@ -355,7 +355,7 @@ public class QueueManager : IQueueManager
             DeduplicationKey = deduplicationKey,
             Status = MessageStatus.Ready,
             RetryCount = 0,
-            MaxRetries = 3, // Default, should come from handler options
+            MaxRetries = _options.DefaultMaxRetries,
             Lease = null,
             LastPersistedVersion = 0,
             Metadata = new MessageMetadata


### PR DESCRIPTION
…d retry configuration

Fixed critical issues identified in docs/phase1-2-evaluation.md:

1. **Deduplication now replaces Ready messages** (not just InFlight)
   - CircularBuffer.ReplaceAsync now supersedes messages in Ready OR InFlight status
   - Aligns with design requirement that newer messages replace older ones
   - Updated tests to reflect new supersede behavior

2. **Added optimistic concurrency to DeduplicationIndex**
   - New overload: UpdateAsync(key, expectedOldMessageId, newMessageId)
   - Only updates if current value matches expected (prevents race conditions)
   - Addresses plan requirement for conflict detection

3. **Fixed hardcoded retry limit**
   - QueueManager.CreateEnvelope now uses _options.DefaultMaxRetries (5)
   - Previously hardcoded to 3
   - Updated tests to use correct default value

4. **Fixed TimeSpan default parameter handling**
   - CheckoutAsync now properly checks for default(TimeSpan) instead of using ?? operator
   - Fixes compilation error with non-nullable struct

Test Results:
- Core: 43/43 passing (100%)
- Persistence: 63/63 passing, 1 skipped (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)