### PR TITLE
Avoid running .NET Framework tests on Linux

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(OS)' != 'Windows_NT'">
+    <TargetFrameworks>net8.0</TargetFrameworks>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- ensure test projects only target net8.0 when running on non-Windows agents to avoid the mono host requirement

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e477f55adc832d9582be863972d8d9