### PR TITLE
Apply EditorConfig coding style across solution

### DIFF
--- a/src/MessageQueue.Core.Tests/CircularBufferTests.cs
+++ b/src/MessageQueue.Core.Tests/CircularBufferTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="CircularBufferTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Tests;
 
 using System;

--- a/src/MessageQueue.Core.Tests/DeduplicationIndexTests.cs
+++ b/src/MessageQueue.Core.Tests/DeduplicationIndexTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeduplicationIndexTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Tests;
 
 using System;

--- a/src/MessageQueue.Core.Tests/Models/DeadLetterEnvelopeTests.cs
+++ b/src/MessageQueue.Core.Tests/Models/DeadLetterEnvelopeTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeadLetterEnvelopeTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Tests.Models;
 
 using System.Text.Json;

--- a/src/MessageQueue.Core.Tests/Models/MessageEnvelopeTests.cs
+++ b/src/MessageQueue.Core.Tests/Models/MessageEnvelopeTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="MessageEnvelopeTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Tests.Models;
 
 using System.Text.Json;

--- a/src/MessageQueue.Core.Tests/QueueManagerTests.cs
+++ b/src/MessageQueue.Core.Tests/QueueManagerTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="QueueManagerTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Tests;
 
 using System;

--- a/src/MessageQueue.Core.Tests/Serialization/SerializationTests.cs
+++ b/src/MessageQueue.Core.Tests/Serialization/SerializationTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="SerializationTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Tests.Serialization;
 
 using System.Text.Json;

--- a/src/MessageQueue.Core/DeduplicationIndex.cs
+++ b/src/MessageQueue.Core/DeduplicationIndex.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeduplicationIndex.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core;
 
 using System;
@@ -11,14 +17,14 @@ using System.Threading.Tasks;
 /// </summary>
 public class DeduplicationIndex
 {
-    private readonly ConcurrentDictionary<string, Guid> _index;
+    private readonly ConcurrentDictionary<string, Guid> index;
 
     /// <summary>
     /// Initializes a new instance of the DeduplicationIndex.
     /// </summary>
     public DeduplicationIndex()
     {
-        _index = new ConcurrentDictionary<string, Guid>(StringComparer.Ordinal);
+        this.index = new ConcurrentDictionary<string, Guid>(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -35,7 +41,7 @@ public class DeduplicationIndex
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        bool added = _index.TryAdd(key, messageId);
+        bool added = this.index.TryAdd(key, messageId);
         return Task.FromResult(added);
     }
 
@@ -52,7 +58,7 @@ public class DeduplicationIndex
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (_index.TryGetValue(key, out Guid messageId))
+        if (this.index.TryGetValue(key, out Guid messageId))
         {
             return Task.FromResult<Guid?>(messageId);
         }
@@ -77,7 +83,7 @@ public class DeduplicationIndex
 
         // Optimistic concurrency: only update if the current value matches expected
         bool updated = false;
-        _index.AddOrUpdate(
+        this.index.AddOrUpdate(
             key,
             newMessageId, // If key doesn't exist, add it (shouldn't happen in update scenario)
             (k, currentValue) =>
@@ -109,7 +115,7 @@ public class DeduplicationIndex
         cancellationToken.ThrowIfCancellationRequested();
 
         // AddOrUpdate returns the new value
-        _index.AddOrUpdate(key, newMessageId, (k, old) => newMessageId);
+        this.index.AddOrUpdate(key, newMessageId, (k, old) => newMessageId);
         return Task.FromResult(true);
     }
 
@@ -126,7 +132,7 @@ public class DeduplicationIndex
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        bool removed = _index.TryRemove(key, out _);
+        bool removed = this.index.TryRemove(key, out _);
         return Task.FromResult(removed);
     }
 
@@ -143,7 +149,7 @@ public class DeduplicationIndex
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        bool contains = _index.ContainsKey(key);
+        bool contains = this.index.ContainsKey(key);
         return Task.FromResult(contains);
     }
 
@@ -155,7 +161,7 @@ public class DeduplicationIndex
     public Task<int> GetCountAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult(_index.Count);
+        return Task.FromResult(this.index.Count);
     }
 
     /// <summary>
@@ -165,7 +171,7 @@ public class DeduplicationIndex
     public Task ClearAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        _index.Clear();
+        this.index.Clear();
         return Task.CompletedTask;
     }
 
@@ -178,7 +184,7 @@ public class DeduplicationIndex
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var snapshot = new System.Collections.Generic.Dictionary<string, Guid>(_index, StringComparer.Ordinal);
+        var snapshot = new System.Collections.Generic.Dictionary<string, Guid>(this.index, StringComparer.Ordinal);
         return Task.FromResult(snapshot);
     }
 
@@ -194,10 +200,10 @@ public class DeduplicationIndex
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        _index.Clear();
+        this.index.Clear();
         foreach (var kvp in snapshot)
         {
-            _index.TryAdd(kvp.Key, kvp.Value);
+            this.index.TryAdd(kvp.Key, kvp.Value);
         }
 
         return Task.CompletedTask;

--- a/src/MessageQueue.Core/Enums/MessageStatus.cs
+++ b/src/MessageQueue.Core/Enums/MessageStatus.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="MessageStatus.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Enums;
 
 /// <summary>

--- a/src/MessageQueue.Core/Enums/OperationCode.cs
+++ b/src/MessageQueue.Core/Enums/OperationCode.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="OperationCode.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Enums;
 
 /// <summary>

--- a/src/MessageQueue.Core/HandlerDispatcher.cs
+++ b/src/MessageQueue.Core/HandlerDispatcher.cs
@@ -140,8 +140,8 @@ namespace MessageQueue.Core
                 {
                     MessageType = messageType,
                     ActiveWorkers = 0,
-                    TotalProcessed = 0,
-                    TotalFailed = 0,
+                    this.TotalProcessed = 0,
+                    this.TotalFailed = 0,
                     AverageExecutionTime = TimeSpan.Zero
                 });
             }
@@ -152,8 +152,8 @@ namespace MessageQueue.Core
             {
                 MessageType = messageType,
                 ActiveWorkers = activeWorkers,
-                TotalProcessed = handlerMetrics.TotalProcessed,
-                TotalFailed = handlerMetrics.TotalFailed,
+                this.TotalProcessed = handlerMetrics.TotalProcessed,
+                this.TotalFailed = handlerMetrics.TotalFailed,
                 AverageExecutionTime = handlerMetrics.GetAverageExecutionTime()
             });
         }
@@ -174,8 +174,8 @@ namespace MessageQueue.Core
                 {
                     MessageType = messageType.FullName ?? messageType.Name,
                     ActiveWorkers = activeWorkers,
-                    TotalProcessed = handlerMetrics.TotalProcessed,
-                    TotalFailed = handlerMetrics.TotalFailed,
+                    this.TotalProcessed = handlerMetrics.TotalProcessed,
+                    this.TotalFailed = handlerMetrics.TotalFailed,
                     AverageProcessingTimeMs = avgTime.TotalMilliseconds,
                     MessagesPerSecond = this.CalculateThroughput(handlerMetrics)
                 };

--- a/src/MessageQueue.Core/Interfaces/ICircularBuffer.cs
+++ b/src/MessageQueue.Core/Interfaces/ICircularBuffer.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="ICircularBuffer.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Interfaces;
 
 using MessageQueue.Core.Models;

--- a/src/MessageQueue.Core/Interfaces/IDeadLetterQueue.cs
+++ b/src/MessageQueue.Core/Interfaces/IDeadLetterQueue.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="IDeadLetterQueue.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Interfaces;
 
 using MessageQueue.Core.Models;

--- a/src/MessageQueue.Core/Interfaces/IHandlerDispatcher.cs
+++ b/src/MessageQueue.Core/Interfaces/IHandlerDispatcher.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="IHandlerDispatcher.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Interfaces
 {
     using System;

--- a/src/MessageQueue.Core/Interfaces/ILeaseMonitor.cs
+++ b/src/MessageQueue.Core/Interfaces/ILeaseMonitor.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="ILeaseMonitor.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Interfaces;
 
 /// <summary>

--- a/src/MessageQueue.Core/Interfaces/IMessageHandler.cs
+++ b/src/MessageQueue.Core/Interfaces/IMessageHandler.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="IMessageHandler.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Interfaces;
 
 /// <summary>

--- a/src/MessageQueue.Core/Interfaces/IPersister.cs
+++ b/src/MessageQueue.Core/Interfaces/IPersister.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="IPersister.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Interfaces;
 
 using MessageQueue.Core.Models;

--- a/src/MessageQueue.Core/Interfaces/IQueueManager.cs
+++ b/src/MessageQueue.Core/Interfaces/IQueueManager.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="IQueueManager.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Interfaces;
 
 using MessageQueue.Core.Enums;

--- a/src/MessageQueue.Core/Interfaces/IQueuePublisher.cs
+++ b/src/MessageQueue.Core/Interfaces/IQueuePublisher.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="IQueuePublisher.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Interfaces;
 
 /// <summary>

--- a/src/MessageQueue.Core/Models/DeadLetterEnvelope.cs
+++ b/src/MessageQueue.Core/Models/DeadLetterEnvelope.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeadLetterEnvelope.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Models;
 
 /// <summary>

--- a/src/MessageQueue.Core/Models/MessageEnvelope.cs
+++ b/src/MessageQueue.Core/Models/MessageEnvelope.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="MessageEnvelope.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Models;
 
 using System.Text.Json.Serialization;

--- a/src/MessageQueue.Core/Models/OperationRecord.cs
+++ b/src/MessageQueue.Core/Models/OperationRecord.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="OperationRecord.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Models;
 
 using MessageQueue.Core.Enums;

--- a/src/MessageQueue.Core/Models/QueueSnapshot.cs
+++ b/src/MessageQueue.Core/Models/QueueSnapshot.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="QueueSnapshot.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Models;
 
 /// <summary>

--- a/src/MessageQueue.Core/Options/HandlerOptions.cs
+++ b/src/MessageQueue.Core/Options/HandlerOptions.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="HandlerOptions.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Options;
 
 using System.ComponentModel.DataAnnotations;

--- a/src/MessageQueue.Core/Options/PersistenceOptions.cs
+++ b/src/MessageQueue.Core/Options/PersistenceOptions.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="PersistenceOptions.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Options;
 
 using System.ComponentModel.DataAnnotations;

--- a/src/MessageQueue.Core/Options/QueueOptions.cs
+++ b/src/MessageQueue.Core/Options/QueueOptions.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="QueueOptions.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Core.Options;
 
 using System.ComponentModel.DataAnnotations;

--- a/src/MessageQueue.Dispatcher.Tests/Unit/HandlerRegistryTests.cs
+++ b/src/MessageQueue.Dispatcher.Tests/Unit/HandlerRegistryTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="HandlerRegistryTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Dispatcher.Tests.Unit;
 
 using System;
@@ -11,8 +17,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class HandlerRegistryTests
 {
-    private IServiceProvider _serviceProvider = null!;
-    private HandlerRegistry _registry = null!;
+    private IServiceProvider serviceProvider = null!;
+    private HandlerRegistry registry = null!;
 
     [TestInitialize]
     public void Setup()
@@ -20,24 +26,24 @@ public class HandlerRegistryTests
         var services = new ServiceCollection();
         services.AddTransient<TestMessageHandler>();
         services.AddTransient<AnotherTestMessageHandler>();
-        _serviceProvider = services.BuildServiceProvider();
-        _registry = new HandlerRegistry(_serviceProvider);
+        this.serviceProvider = services.BuildServiceProvider();
+        this.registry = new HandlerRegistry(this.serviceProvider);
     }
 
     [TestCleanup]
     public void Cleanup()
     {
-        (_serviceProvider as IDisposable)?.Dispose();
+        (this.serviceProvider as IDisposable)?.Dispose();
     }
 
     [TestMethod]
     public void RegisterHandler_WithTypeParameters_RegistersSuccessfully()
     {
         // Act
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>();
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>();
 
         // Assert
-        var isRegistered = _registry.IsRegistered(typeof(TestMessage));
+        var isRegistered = this.registry.IsRegistered(typeof(TestMessage));
         isRegistered.Should().BeTrue();
     }
 
@@ -54,10 +60,10 @@ public class HandlerRegistryTests
         };
 
         // Act
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>(options);
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>(options);
 
         // Assert
-        var registration = _registry.GetRegistration(typeof(TestMessage));
+        var registration = this.registry.GetRegistration(typeof(TestMessage));
         registration.Should().NotBeNull();
         registration.Options.Should().Be(options);
     }
@@ -70,10 +76,10 @@ public class HandlerRegistryTests
             sp => new TestMessageHandler();
 
         // Act
-        _registry.RegisterHandler(factory);
+        this.registry.RegisterHandler(factory);
 
         // Assert
-        var isRegistered = _registry.IsRegistered(typeof(TestMessage));
+        var isRegistered = this.registry.IsRegistered(typeof(TestMessage));
         isRegistered.Should().BeTrue();
     }
 
@@ -81,10 +87,10 @@ public class HandlerRegistryTests
     public void GetRegistration_WhenRegistered_ReturnsRegistration()
     {
         // Arrange
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>();
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>();
 
         // Act
-        var registration = _registry.GetRegistration(typeof(TestMessage));
+        var registration = this.registry.GetRegistration(typeof(TestMessage));
 
         // Assert
         registration.Should().NotBeNull();
@@ -96,7 +102,7 @@ public class HandlerRegistryTests
     public void GetRegistration_WhenNotRegistered_ReturnsNull()
     {
         // Act
-        var registration = _registry.GetRegistration(typeof(TestMessage));
+        var registration = this.registry.GetRegistration(typeof(TestMessage));
 
         // Assert
         registration.Should().BeNull();
@@ -106,10 +112,10 @@ public class HandlerRegistryTests
     public void IsRegistered_WhenRegistered_ReturnsTrue()
     {
         // Arrange
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>();
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>();
 
         // Act
-        var isRegistered = _registry.IsRegistered(typeof(TestMessage));
+        var isRegistered = this.registry.IsRegistered(typeof(TestMessage));
 
         // Assert
         isRegistered.Should().BeTrue();
@@ -119,7 +125,7 @@ public class HandlerRegistryTests
     public void IsRegistered_WhenNotRegistered_ReturnsFalse()
     {
         // Act
-        var isRegistered = _registry.IsRegistered(typeof(TestMessage));
+        var isRegistered = this.registry.IsRegistered(typeof(TestMessage));
 
         // Assert
         isRegistered.Should().BeFalse();
@@ -129,11 +135,11 @@ public class HandlerRegistryTests
     public void GetRegisteredMessageTypes_ReturnsAllRegisteredTypes()
     {
         // Arrange
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>();
-        _registry.RegisterHandler<AnotherTestMessage, AnotherTestMessageHandler>();
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>();
+        this.registry.RegisterHandler<AnotherTestMessage, AnotherTestMessageHandler>();
 
         // Act
-        var messageTypes = _registry.GetRegisteredMessageTypes();
+        var messageTypes = this.registry.GetRegisteredMessageTypes();
 
         // Assert
         messageTypes.Should().Contain(typeof(TestMessage));
@@ -144,10 +150,10 @@ public class HandlerRegistryTests
     public void CreateHandler_WhenRegistered_CreatesHandlerInstance()
     {
         // Arrange
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>();
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>();
 
         // Act
-        var handler = _registry.CreateHandler(typeof(TestMessage));
+        var handler = this.registry.CreateHandler(typeof(TestMessage));
 
         // Assert
         handler.Should().NotBeNull();
@@ -158,7 +164,7 @@ public class HandlerRegistryTests
     public void CreateHandler_WhenNotRegistered_ThrowsException()
     {
         // Act & Assert
-        var act = () => _registry.CreateHandler(typeof(TestMessage));
+        var act = () => this.registry.CreateHandler(typeof(TestMessage));
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("No handler registered for message type: *TestMessage*");
     }
@@ -167,12 +173,12 @@ public class HandlerRegistryTests
     public void CreateScopedHandler_WithScope_CreatesHandlerInstance()
     {
         // Arrange
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>();
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>();
 
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = this.serviceProvider.CreateScope();
 
         // Act
-        var handler = _registry.CreateScopedHandler(typeof(TestMessage), scope);
+        var handler = this.registry.CreateScopedHandler(typeof(TestMessage), scope);
 
         // Assert
         handler.Should().NotBeNull();
@@ -183,10 +189,10 @@ public class HandlerRegistryTests
     public void CreateScopedHandler_WithNullScope_ThrowsException()
     {
         // Arrange
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>();
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>();
 
         // Act & Assert
-        var act = () => _registry.CreateScopedHandler(typeof(TestMessage), null);
+        var act = () => this.registry.CreateScopedHandler(typeof(TestMessage), null);
         act.Should().Throw<ArgumentNullException>();
     }
 
@@ -194,10 +200,10 @@ public class HandlerRegistryTests
     public void CreateScopedHandler_WhenNotRegistered_ThrowsException()
     {
         // Arrange
-        using var scope = _serviceProvider.CreateScope();
+        using var scope = this.serviceProvider.CreateScope();
 
         // Act & Assert
-        var act = () => _registry.CreateScopedHandler(typeof(TestMessage), scope);
+        var act = () => this.registry.CreateScopedHandler(typeof(TestMessage), scope);
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("No handler registered for message type: *TestMessage*");
     }
@@ -210,11 +216,11 @@ public class HandlerRegistryTests
         var options2 = new HandlerOptions<TestMessage> { MinParallelism = 5 };
 
         // Act
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>(options1);
-        _registry.RegisterHandler<TestMessage, TestMessageHandler>(options2);
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>(options1);
+        this.registry.RegisterHandler<TestMessage, TestMessageHandler>(options2);
 
         // Assert
-        var registration = _registry.GetRegistration(typeof(TestMessage));
+        var registration = this.registry.GetRegistration(typeof(TestMessage));
         registration.Options.Should().Be(options2);
     }
 

--- a/src/MessageQueue.Integration.Tests/Phase6/HandlerChainingTests.cs
+++ b/src/MessageQueue.Integration.Tests/Phase6/HandlerChainingTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="HandlerChainingTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Integration.Tests.Phase6;
 
 using System;
@@ -12,24 +18,24 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class HandlerChainingTests
 {
-    private IQueueManager _queueManager = null!;
-    private IQueuePublisher _publisher = null!;
-    private QueueOptions _options = null!;
+    private IQueueManager queueManager = null!;
+    private IQueuePublisher publisher = null!;
+    private QueueOptions options = null!;
 
     [TestInitialize]
     public void Setup()
     {
         var buffer = new CircularBuffer(100);
         var dedupIndex = new DeduplicationIndex();
-        _options = new QueueOptions
+        this.options = new QueueOptions
         {
             Capacity = 100,
             DefaultTimeout = TimeSpan.FromMinutes(5),
             DefaultMaxRetries = 3
         };
 
-        _queueManager = new QueueManager(buffer, dedupIndex, _options);
-        _publisher = new QueuePublisher(_queueManager);
+        this.queueManager = new QueueManager(buffer, dedupIndex, this.options);
+        this.publisher = new QueuePublisher(this.queueManager);
     }
 
     [TestMethod]
@@ -39,11 +45,11 @@ public class HandlerChainingTests
         var testMessage = new TestMessage { Id = 1, Name = "Test" };
 
         // Act
-        var messageId = await _publisher.EnqueueAsync(testMessage);
+        var messageId = await this.publisher.EnqueueAsync(testMessage);
 
         // Assert
         messageId.Should().NotBeEmpty();
-        var count = await _queueManager.GetCountAsync();
+        var count = await this.queueManager.GetCountAsync();
         count.Should().Be(1);
     }
 
@@ -55,10 +61,10 @@ public class HandlerChainingTests
         var correlationId = Guid.NewGuid().ToString();
 
         // Act
-        var messageId = await _publisher.EnqueueAsync(testMessage, correlationId: correlationId);
+        var messageId = await this.publisher.EnqueueAsync(testMessage, correlationId: correlationId);
 
         // Assert
-        var envelope = await _queueManager.GetMessageAsync(messageId);
+        var envelope = await this.queueManager.GetMessageAsync(messageId);
         envelope.Should().NotBeNull();
         envelope!.Metadata.CorrelationId.Should().Be(correlationId);
     }
@@ -71,10 +77,10 @@ public class HandlerChainingTests
 
         // Step 1: Enqueue initial message
         var step1Message = new Step1Message { OrderId = "ORDER-001" };
-        var step1Id = await _publisher.EnqueueAsync(step1Message, correlationId: correlationId);
+        var step1Id = await this.publisher.EnqueueAsync(step1Message, correlationId: correlationId);
 
         // Simulate handler processing and enqueuing next step
-        var step1Envelope = await _queueManager.CheckoutAsync<Step1Message>("handler-1");
+        var step1Envelope = await this.queueManager.CheckoutAsync<Step1Message>("handler-1");
         step1Envelope.Should().NotBeNull();
 
         // Step 2: Handler chains to next message with same correlation ID
@@ -83,14 +89,14 @@ public class HandlerChainingTests
             OrderId = step1Envelope!.Message.OrderId,
             ProcessedBy = "Step1Handler"
         };
-        var step2Id = await _publisher.EnqueueAsync(
+        var step2Id = await this.publisher.EnqueueAsync(
             step2Message,
             correlationId: step1Envelope.Metadata.CorrelationId);
 
-        await _queueManager.AcknowledgeAsync(step1Id);
+        await this.queueManager.AcknowledgeAsync(step1Id);
 
         // Step 3: Verify step 2 has same correlation ID
-        var step2Envelope = await _queueManager.CheckoutAsync<Step2Message>("handler-2");
+        var step2Envelope = await this.queueManager.CheckoutAsync<Step2Message>("handler-2");
         step2Envelope.Should().NotBeNull();
         step2Envelope!.Metadata.CorrelationId.Should().Be(correlationId);
         step2Envelope.Message.OrderId.Should().Be("ORDER-001");
@@ -105,15 +111,15 @@ public class HandlerChainingTests
 
         // Act - Try to enqueue same chained message twice
         var message1 = new Step2Message { OrderId = "ORDER-001", ProcessedBy = "Step1" };
-        var id1 = await _publisher.EnqueueAsync(message1, dedupKey, correlationId);
+        var id1 = await this.publisher.EnqueueAsync(message1, dedupKey, correlationId);
 
         var message2 = new Step2Message { OrderId = "ORDER-001", ProcessedBy = "Step1" };
-        var id2 = await _publisher.EnqueueAsync(message2, dedupKey, correlationId);
+        var id2 = await this.publisher.EnqueueAsync(message2, dedupKey, correlationId);
 
         // Assert - Both enqueues should succeed (dedup doesn't prevent new messages with same key)
         // The second one creates a new message since the first one is still in Ready state
         id2.Should().NotBeEmpty();
-        var count = await _queueManager.GetCountAsync();
+        var count = await this.queueManager.GetCountAsync();
         count.Should().BeGreaterOrEqualTo(1);
     }
 
@@ -126,28 +132,28 @@ public class HandlerChainingTests
 
         // Step 1: Order validation
         var step1 = new OrderValidationMessage { OrderId = orderId };
-        var step1Id = await _publisher.EnqueueAsync(step1, correlationId: correlationId);
+        var step1Id = await this.publisher.EnqueueAsync(step1, correlationId: correlationId);
 
         // Process step 1
-        var step1Env = await _queueManager.CheckoutAsync<OrderValidationMessage>("validator");
+        var step1Env = await this.queueManager.CheckoutAsync<OrderValidationMessage>("validator");
         step1Env.Should().NotBeNull();
-        await _queueManager.AcknowledgeAsync(step1Id);
+        await this.queueManager.AcknowledgeAsync(step1Id);
 
         // Step 2: Payment processing (chained from step 1)
         var step2 = new PaymentProcessingMessage { OrderId = orderId, Amount = 99.99m };
-        var step2Id = await _publisher.EnqueueAsync(step2, correlationId: step1Env!.Metadata.CorrelationId);
+        var step2Id = await this.publisher.EnqueueAsync(step2, correlationId: step1Env!.Metadata.CorrelationId);
 
         // Process step 2
-        var step2Env = await _queueManager.CheckoutAsync<PaymentProcessingMessage>("payment");
+        var step2Env = await this.queueManager.CheckoutAsync<PaymentProcessingMessage>("payment");
         step2Env.Should().NotBeNull();
-        await _queueManager.AcknowledgeAsync(step2Id);
+        await this.queueManager.AcknowledgeAsync(step2Id);
 
         // Step 3: Fulfillment (chained from step 2)
         var step3 = new FulfillmentMessage { OrderId = orderId };
-        var step3Id = await _publisher.EnqueueAsync(step3, correlationId: step2Env!.Metadata.CorrelationId);
+        var step3Id = await this.publisher.EnqueueAsync(step3, correlationId: step2Env!.Metadata.CorrelationId);
 
         // Process step 3
-        var step3Env = await _queueManager.CheckoutAsync<FulfillmentMessage>("fulfillment");
+        var step3Env = await this.queueManager.CheckoutAsync<FulfillmentMessage>("fulfillment");
         step3Env.Should().NotBeNull();
 
         // Assert - All steps have same correlation ID
@@ -155,7 +161,7 @@ public class HandlerChainingTests
         step2Env.Metadata.CorrelationId.Should().Be(correlationId);
         step3Env!.Metadata.CorrelationId.Should().Be(correlationId);
 
-        await _queueManager.AcknowledgeAsync(step3Id);
+        await this.queueManager.AcknowledgeAsync(step3Id);
     }
 
     // Test message classes

--- a/src/MessageQueue.Integration.Tests/Phase6/LongRunningHandlerTests.cs
+++ b/src/MessageQueue.Integration.Tests/Phase6/LongRunningHandlerTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="LongRunningHandlerTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Integration.Tests.Phase6;
 
 using System;
@@ -12,34 +18,34 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class LongRunningHandlerTests
 {
-    private IQueueManager _queueManager = null!;
-    private ILeaseMonitor _leaseMonitor = null!;
-    private IHeartbeatService _heartbeatService = null!;
-    private QueueOptions _options = null!;
+    private IQueueManager queueManager = null!;
+    private ILeaseMonitor leaseMonitor = null!;
+    private IHeartbeatService heartbeatService = null!;
+    private QueueOptions options = null!;
 
     [TestInitialize]
     public void Setup()
     {
         var buffer = new CircularBuffer(100);
         var dedupIndex = new DeduplicationIndex();
-        _options = new QueueOptions
+        this.options = new QueueOptions
         {
             Capacity = 100,
             DefaultTimeout = TimeSpan.FromSeconds(2),
             DefaultMaxRetries = 3
         };
 
-        _queueManager = new QueueManager(buffer, dedupIndex, _options);
-        _leaseMonitor = new LeaseMonitor(_queueManager, _options);
-        _heartbeatService = new HeartbeatService(_queueManager, _leaseMonitor, _options);
+        this.queueManager = new QueueManager(buffer, dedupIndex, this.options);
+        this.leaseMonitor = new LeaseMonitor(this.queueManager, this.options);
+        this.heartbeatService = new HeartbeatService(this.queueManager, this.leaseMonitor, this.options);
     }
 
     [TestCleanup]
     public async Task Cleanup()
     {
-        if (_leaseMonitor != null)
+        if (this.leaseMonitor != null)
         {
-            await _leaseMonitor.StopAsync();
+            await this.leaseMonitor.StopAsync();
         }
     }
 
@@ -47,15 +53,15 @@ public class LongRunningHandlerTests
     public async Task HeartbeatService_RecordsHeartbeat_Successfully()
     {
         // Arrange
-        var messageId = await _queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-001" });
-        var envelope = await _queueManager.CheckoutAsync<LongRunningTask>("worker-1");
+        var messageId = await this.queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-001" });
+        var envelope = await this.queueManager.CheckoutAsync<LongRunningTask>("worker-1");
         envelope.Should().NotBeNull();
 
         // Act
-        await _heartbeatService.HeartbeatAsync(messageId, progressPercentage: 25, progressMessage: "Processing...");
+        await this.heartbeatService.HeartbeatAsync(messageId, progressPercentage: 25, progressMessage: "Processing...");
 
         // Assert
-        var progress = await _heartbeatService.GetProgressAsync(messageId);
+        var progress = await this.heartbeatService.GetProgressAsync(messageId);
         progress.Should().NotBeNull();
         progress!.ProgressPercentage.Should().Be(25);
         progress.ProgressMessage.Should().Be("Processing...");
@@ -66,18 +72,18 @@ public class LongRunningHandlerTests
     public async Task HeartbeatService_MultipleHeartbeats_UpdatesProgress()
     {
         // Arrange
-        var messageId = await _queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-002" });
-        var envelope = await _queueManager.CheckoutAsync<LongRunningTask>("worker-1");
+        var messageId = await this.queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-002" });
+        var envelope = await this.queueManager.CheckoutAsync<LongRunningTask>("worker-1");
 
         // Act - Send multiple heartbeats
-        await _heartbeatService.HeartbeatAsync(messageId, 10, "Starting");
+        await this.heartbeatService.HeartbeatAsync(messageId, 10, "Starting");
         await Task.Delay(100);
-        await _heartbeatService.HeartbeatAsync(messageId, 50, "Halfway");
+        await this.heartbeatService.HeartbeatAsync(messageId, 50, "Halfway");
         await Task.Delay(100);
-        await _heartbeatService.HeartbeatAsync(messageId, 90, "Almost done");
+        await this.heartbeatService.HeartbeatAsync(messageId, 90, "Almost done");
 
         // Assert
-        var progress = await _heartbeatService.GetProgressAsync(messageId);
+        var progress = await this.heartbeatService.GetProgressAsync(messageId);
         progress.Should().NotBeNull();
         progress!.ProgressPercentage.Should().Be(90);
         progress.ProgressMessage.Should().Be("Almost done");
@@ -88,42 +94,42 @@ public class LongRunningHandlerTests
     public async Task HeartbeatService_ExtendsLease_PreventTimeout()
     {
         // Arrange
-        await _leaseMonitor.StartAsync();
+        await this.leaseMonitor.StartAsync();
 
-        var messageId = await _queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-003" });
-        var envelope = await _queueManager.CheckoutAsync<LongRunningTask>("worker-1", TimeSpan.FromMilliseconds(500));
+        var messageId = await this.queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-003" });
+        var envelope = await this.queueManager.CheckoutAsync<LongRunningTask>("worker-1", TimeSpan.FromMilliseconds(500));
         envelope.Should().NotBeNull();
 
         // Act - Send heartbeat before lease expires
         await Task.Delay(300);
-        await _heartbeatService.HeartbeatAsync(messageId, 50, "Still working");
+        await this.heartbeatService.HeartbeatAsync(messageId, 50, "Still working");
 
         // Wait another 400ms (would have expired without heartbeat)
         await Task.Delay(400);
 
         // Assert - Message should still be checked out (lease extended)
-        var status = await _queueManager.GetMessageAsync(messageId);
+        var status = await this.queueManager.GetMessageAsync(messageId);
         status.Should().NotBeNull();
 
-        var tryCheckout = await _queueManager.CheckoutAsync<LongRunningTask>("worker-2");
+        var tryCheckout = await this.queueManager.CheckoutAsync<LongRunningTask>("worker-2");
         tryCheckout.Should().BeNull(); // Still held by worker-1
 
-        await _queueManager.AcknowledgeAsync(messageId);
+        await this.queueManager.AcknowledgeAsync(messageId);
     }
 
     [TestMethod]
     public async Task HeartbeatService_InvalidProgressPercentage_ThrowsException()
     {
         // Arrange
-        var messageId = await _queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-004" });
-        await _queueManager.CheckoutAsync<LongRunningTask>("worker-1");
+        var messageId = await this.queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-004" });
+        await this.queueManager.CheckoutAsync<LongRunningTask>("worker-1");
 
         // Act & Assert - Progress > 100
-        var act1 = async () => await _heartbeatService.HeartbeatAsync(messageId, 150);
+        var act1 = async () => await this.heartbeatService.HeartbeatAsync(messageId, 150);
         await act1.Should().ThrowAsync<ArgumentOutOfRangeException>();
 
         // Act & Assert - Progress < 0
-        var act2 = async () => await _heartbeatService.HeartbeatAsync(messageId, -10);
+        var act2 = async () => await this.heartbeatService.HeartbeatAsync(messageId, -10);
         await act2.Should().ThrowAsync<ArgumentOutOfRangeException>();
     }
 
@@ -131,17 +137,17 @@ public class LongRunningHandlerTests
     public async Task HeartbeatService_GetLastHeartbeat_ReturnsTimestamp()
     {
         // Arrange
-        var messageId = await _queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-005" });
-        await _queueManager.CheckoutAsync<LongRunningTask>("worker-1");
+        var messageId = await this.queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-005" });
+        await this.queueManager.CheckoutAsync<LongRunningTask>("worker-1");
 
         var beforeHeartbeat = DateTime.UtcNow;
 
         // Act
-        await _heartbeatService.HeartbeatAsync(messageId, 50);
+        await this.heartbeatService.HeartbeatAsync(messageId, 50);
         await Task.Delay(50);
 
         // Assert
-        var lastHeartbeat = await _heartbeatService.GetLastHeartbeatAsync(messageId);
+        var lastHeartbeat = await this.heartbeatService.GetLastHeartbeatAsync(messageId);
         lastHeartbeat.Should().NotBeNull();
         lastHeartbeat.Should().BeOnOrAfter(beforeHeartbeat);
     }
@@ -150,14 +156,14 @@ public class LongRunningHandlerTests
     public async Task HeartbeatService_CompletedMessage_ThrowsException()
     {
         // Arrange
-        var messageId = await _queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-006" });
-        await _queueManager.CheckoutAsync<LongRunningTask>("worker-1");
+        var messageId = await this.queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-006" });
+        await this.queueManager.CheckoutAsync<LongRunningTask>("worker-1");
 
         // Complete the message
-        await _queueManager.AcknowledgeAsync(messageId);
+        await this.queueManager.AcknowledgeAsync(messageId);
 
         // Act & Assert - Heartbeat on completed message should fail
-        var act = async () => await _heartbeatService.HeartbeatAsync(messageId, 100);
+        var act = async () => await this.heartbeatService.HeartbeatAsync(messageId, 100);
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
@@ -165,29 +171,29 @@ public class LongRunningHandlerTests
     public async Task LongRunningHandler_WithHeartbeats_CompletesSuccessfully()
     {
         // Arrange - Simulate long-running task
-        await _leaseMonitor.StartAsync();
+        await this.leaseMonitor.StartAsync();
 
-        var messageId = await _queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-007" });
-        var envelope = await _queueManager.CheckoutAsync<LongRunningTask>("worker-1", TimeSpan.FromSeconds(1));
+        var messageId = await this.queueManager.EnqueueAsync(new LongRunningTask { TaskId = "TASK-007" });
+        var envelope = await this.queueManager.CheckoutAsync<LongRunningTask>("worker-1", TimeSpan.FromSeconds(1));
 
         // Act - Simulate long task with periodic heartbeats
         for (int i = 1; i <= 5; i++)
         {
             await Task.Delay(400); // Total 2 seconds (longer than initial 1s lease)
-            await _heartbeatService.HeartbeatAsync(
+            await this.heartbeatService.HeartbeatAsync(
                 messageId,
                 progressPercentage: i * 20,
                 progressMessage: $"Step {i} of 5");
         }
 
         // Assert - Message still active despite time > original lease
-        var progress = await _heartbeatService.GetProgressAsync(messageId);
+        var progress = await this.heartbeatService.GetProgressAsync(messageId);
         progress.Should().NotBeNull();
         progress!.ProgressPercentage.Should().Be(100);
         progress.HeartbeatCount.Should().Be(5);
 
         // Complete the task
-        await _queueManager.AcknowledgeAsync(messageId);
+        await this.queueManager.AcknowledgeAsync(messageId);
     }
 
     // Test message class

--- a/src/MessageQueue.Integration.Tests/Scenarios/DeadLetterQueueIntegrationTests.cs
+++ b/src/MessageQueue.Integration.Tests/Scenarios/DeadLetterQueueIntegrationTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="DeadLetterQueueIntegrationTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Integration.Tests.Scenarios;
 
 using System;
@@ -12,41 +18,41 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class DeadLetterQueueIntegrationTests
 {
-    private IQueueManager _queueManager = null!;
-    private IDeadLetterQueue _dlq = null!;
-    private ILeaseMonitor _leaseMonitor = null!;
-    private QueueOptions _options = null!;
+    private IQueueManager queueManager = null!;
+    private IDeadLetterQueue dlq = null!;
+    private ILeaseMonitor leaseMonitor = null!;
+    private QueueOptions options = null!;
 
     [TestInitialize]
     public void Setup()
     {
         var buffer = new CircularBuffer(100);
         var dedupIndex = new DeduplicationIndex();
-        _options = new QueueOptions
+        this.options = new QueueOptions
         {
             Capacity = 100,
             DefaultTimeout = TimeSpan.FromMinutes(5),
             DefaultMaxRetries = 3
         };
 
-        _dlq = new DeadLetterQueue(null, _options); // We'll create QueueManager with DLQ next
-        _queueManager = new QueueManager(buffer, dedupIndex, _options, null, _dlq);
+        this.dlq = new DeadLetterQueue(null, this.options); // We'll create QueueManager with DLQ next
+        this.queueManager = new QueueManager(buffer, dedupIndex, this.options, null, this.dlq);
 
         // Recreate DLQ with actual queue manager
-        _dlq = new DeadLetterQueue(_queueManager, _options);
+        this.dlq = new DeadLetterQueue(this.queueManager, this.options);
 
         // Recreate queue manager with proper DLQ
-        _queueManager = new QueueManager(buffer, dedupIndex, _options, null, _dlq);
+        this.queueManager = new QueueManager(buffer, dedupIndex, this.options, null, this.dlq);
 
-        _leaseMonitor = new LeaseMonitor(_queueManager, _options);
+        this.leaseMonitor = new LeaseMonitor(this.queueManager, this.options);
     }
 
     [TestCleanup]
     public async Task Cleanup()
     {
-        if (_leaseMonitor != null)
+        if (this.leaseMonitor != null)
         {
-            await _leaseMonitor.StopAsync();
+            await this.leaseMonitor.StopAsync();
         }
     }
 
@@ -54,18 +60,18 @@ public class DeadLetterQueueIntegrationTests
     public async Task EndToEnd_MaxRetriesExceeded_MovesToDLQ()
     {
         // Arrange
-        var messageId = await _queueManager.EnqueueAsync("Test message");
+        var messageId = await this.queueManager.EnqueueAsync("Test message");
 
         // Act - simulate max retries
         for (int i = 0; i < 4; i++) // 3 retries + 1 final attempt = 4
         {
-            var checkedOut = await _queueManager.CheckoutAsync<string>("worker-1");
+            var checkedOut = await this.queueManager.CheckoutAsync<string>("worker-1");
             if (checkedOut == null)
                 break;
 
             try
             {
-                await _queueManager.RequeueAsync(checkedOut.MessageId, new Exception($"Attempt {i + 1} failed"));
+                await this.queueManager.RequeueAsync(checkedOut.MessageId, new Exception($"Attempt {i + 1} failed"));
             }
             catch (InvalidOperationException)
             {
@@ -75,7 +81,7 @@ public class DeadLetterQueueIntegrationTests
         }
 
         // Assert
-        var dlqMessages = await _dlq.GetMessagesAsync();
+        var dlqMessages = await this.dlq.GetMessagesAsync();
         dlqMessages.Should().HaveCount(1);
         var dlqMessage = dlqMessages.First();
         dlqMessage.FailureReason.Should().Contain("Max retries exceeded");
@@ -86,17 +92,17 @@ public class DeadLetterQueueIntegrationTests
     public async Task EndToEnd_DLQReplay_ReenqueuesMessage()
     {
         // Arrange - move message to DLQ
-        var messageId = await _queueManager.EnqueueAsync("Test message");
+        var messageId = await this.queueManager.EnqueueAsync("Test message");
 
         for (int i = 0; i < 4; i++)
         {
-            var checkedOut = await _queueManager.CheckoutAsync<string>("worker-1");
+            var checkedOut = await this.queueManager.CheckoutAsync<string>("worker-1");
             if (checkedOut == null)
                 break;
 
             try
             {
-                await _queueManager.RequeueAsync(checkedOut.MessageId, new Exception("Failed"));
+                await this.queueManager.RequeueAsync(checkedOut.MessageId, new Exception("Failed"));
             }
             catch (InvalidOperationException)
             {
@@ -104,17 +110,17 @@ public class DeadLetterQueueIntegrationTests
             }
         }
 
-        var dlqMessages = await _dlq.GetMessagesAsync();
+        var dlqMessages = await this.dlq.GetMessagesAsync();
         dlqMessages.Should().HaveCount(1);
 
         // Act - replay from DLQ
-        await _dlq.ReplayAsync(dlqMessages.First().MessageId, resetRetryCount: true);
+        await this.dlq.ReplayAsync(dlqMessages.First().MessageId, resetRetryCount: true);
 
         // Assert
-        var dlqAfterReplay = await _dlq.GetMessagesAsync();
+        var dlqAfterReplay = await this.dlq.GetMessagesAsync();
         dlqAfterReplay.Should().BeEmpty();
 
-        var replayedMessage = await _queueManager.CheckoutAsync<string>("worker-2");
+        var replayedMessage = await this.queueManager.CheckoutAsync<string>("worker-2");
         replayedMessage.Should().NotBeNull();
         replayedMessage.Message.Should().Be("Test message");
         replayedMessage.RetryCount.Should().Be(0); // Reset
@@ -124,17 +130,17 @@ public class DeadLetterQueueIntegrationTests
     public async Task EndToEnd_LeaseExpiry_RequeulesMessage()
     {
         // Arrange
-        await _leaseMonitor.StartAsync();
+        await this.leaseMonitor.StartAsync();
 
-        var messageId = await _queueManager.EnqueueAsync("Test message");
-        var checkedOut = await _queueManager.CheckoutAsync<string>("worker-1", TimeSpan.FromMilliseconds(500));
+        var messageId = await this.queueManager.EnqueueAsync("Test message");
+        var checkedOut = await this.queueManager.CheckoutAsync<string>("worker-1", TimeSpan.FromMilliseconds(500));
         checkedOut.Should().NotBeNull();
 
         // Act - wait for lease to expire and monitor to requeue
         await Task.Delay(1500);
 
         // Assert
-        var requeuedMessage = await _queueManager.CheckoutAsync<string>("worker-2");
+        var requeuedMessage = await this.queueManager.CheckoutAsync<string>("worker-2");
         requeuedMessage.Should().NotBeNull();
         requeuedMessage.Message.Should().Be("Test message");
         requeuedMessage.RetryCount.Should().Be(1); // Incremented due to requeue
@@ -144,14 +150,14 @@ public class DeadLetterQueueIntegrationTests
     public async Task EndToEnd_LeaseExpiryWithMaxRetries_MovesToDLQ()
     {
         // Arrange
-        await _leaseMonitor.StartAsync();
+        await this.leaseMonitor.StartAsync();
 
-        var messageId = await _queueManager.EnqueueAsync("Test message");
+        var messageId = await this.queueManager.EnqueueAsync("Test message");
 
         // Act - simulate lease expiry cycles until max retries
         for (int i = 0; i < 4; i++)
         {
-            var checkedOut = await _queueManager.CheckoutAsync<string>($"worker-{i}", TimeSpan.FromMilliseconds(300));
+            var checkedOut = await this.queueManager.CheckoutAsync<string>($"worker-{i}", TimeSpan.FromMilliseconds(300));
             if (checkedOut == null)
                 break;
 
@@ -163,7 +169,7 @@ public class DeadLetterQueueIntegrationTests
         await Task.Delay(500);
 
         // Assert
-        var dlqMessages = await _dlq.GetMessagesAsync();
+        var dlqMessages = await this.dlq.GetMessagesAsync();
         dlqMessages.Should().HaveCount(1);
         dlqMessages.First().FailureReason.Should().Contain("Max retries exceeded");
     }
@@ -172,42 +178,42 @@ public class DeadLetterQueueIntegrationTests
     public async Task EndToEnd_DLQMetrics_TrackFailurePatterns()
     {
         // Arrange - add various failures
-        await _queueManager.EnqueueAsync("Message 1");
-        await _queueManager.EnqueueAsync("Message 2");
-        await _queueManager.EnqueueAsync(123); // Different type
+        await this.queueManager.EnqueueAsync("Message 1");
+        await this.queueManager.EnqueueAsync("Message 2");
+        await this.queueManager.EnqueueAsync(123); // Different type
 
         // Simulate failures
         for (int i = 0; i < 3; i++)
         {
-            var msg1 = await _queueManager.CheckoutAsync<string>("worker-1");
+            var msg1 = await this.queueManager.CheckoutAsync<string>("worker-1");
             if (msg1 != null)
             {
                 try
                 {
                     for (int retry = 0; retry < 4; retry++)
                     {
-                        await _queueManager.RequeueAsync(msg1.MessageId, new TimeoutException("Timeout"));
+                        await this.queueManager.RequeueAsync(msg1.MessageId, new TimeoutException("Timeout"));
                     }
                 }
                 catch { }
             }
         }
 
-        var msg2 = await _queueManager.CheckoutAsync<int>("worker-2");
+        var msg2 = await this.queueManager.CheckoutAsync<int>("worker-2");
         if (msg2 != null)
         {
             try
             {
                 for (int retry = 0; retry < 4; retry++)
                 {
-                    await _queueManager.RequeueAsync(msg2.MessageId, new InvalidOperationException("Invalid"));
+                    await this.queueManager.RequeueAsync(msg2.MessageId, new InvalidOperationException("Invalid"));
                 }
             }
             catch { }
         }
 
         // Act
-        var metrics = await _dlq.GetMetricsAsync();
+        var metrics = await this.dlq.GetMetricsAsync();
 
         // Assert
         metrics.TotalCount.Should().BeGreaterOrEqualTo(2);
@@ -220,17 +226,17 @@ public class DeadLetterQueueIntegrationTests
     public async Task EndToEnd_DLQPurge_RemovesOldMessages()
     {
         // Arrange - add message to DLQ
-        var messageId = await _queueManager.EnqueueAsync("Old message");
+        var messageId = await this.queueManager.EnqueueAsync("Old message");
 
         for (int i = 0; i < 4; i++)
         {
-            var checkedOut = await _queueManager.CheckoutAsync<string>("worker-1");
+            var checkedOut = await this.queueManager.CheckoutAsync<string>("worker-1");
             if (checkedOut == null)
                 break;
 
             try
             {
-                await _queueManager.RequeueAsync(checkedOut.MessageId, new Exception("Failed"));
+                await this.queueManager.RequeueAsync(checkedOut.MessageId, new Exception("Failed"));
             }
             catch
             {
@@ -238,23 +244,23 @@ public class DeadLetterQueueIntegrationTests
             }
         }
 
-        var dlqMessages = await _dlq.GetMessagesAsync();
+        var dlqMessages = await this.dlq.GetMessagesAsync();
         dlqMessages.Should().HaveCount(1);
 
         // Wait a bit
         await Task.Delay(100);
 
         // Add another message
-        var messageId2 = await _queueManager.EnqueueAsync("New message");
+        var messageId2 = await this.queueManager.EnqueueAsync("New message");
         for (int i = 0; i < 4; i++)
         {
-            var checkedOut = await _queueManager.CheckoutAsync<string>("worker-2");
+            var checkedOut = await this.queueManager.CheckoutAsync<string>("worker-2");
             if (checkedOut == null)
                 break;
 
             try
             {
-                await _queueManager.RequeueAsync(checkedOut.MessageId, new Exception("Failed"));
+                await this.queueManager.RequeueAsync(checkedOut.MessageId, new Exception("Failed"));
             }
             catch
             {
@@ -263,10 +269,10 @@ public class DeadLetterQueueIntegrationTests
         }
 
         // Act - purge old messages
-        await _dlq.PurgeAsync(TimeSpan.FromMilliseconds(50));
+        await this.dlq.PurgeAsync(TimeSpan.FromMilliseconds(50));
 
         // Assert - only newer message should remain
-        var remainingMessages = await _dlq.GetMessagesAsync();
+        var remainingMessages = await this.dlq.GetMessagesAsync();
         remainingMessages.Should().HaveCount(1);
     }
 
@@ -274,21 +280,21 @@ public class DeadLetterQueueIntegrationTests
     public async Task EndToEnd_LeaseExtension_PreventsExpiry()
     {
         // Arrange
-        await _leaseMonitor.StartAsync();
+        await this.leaseMonitor.StartAsync();
 
-        var messageId = await _queueManager.EnqueueAsync("Long running task");
-        var checkedOut = await _queueManager.CheckoutAsync<string>("worker-1", TimeSpan.FromMilliseconds(500));
+        var messageId = await this.queueManager.EnqueueAsync("Long running task");
+        var checkedOut = await this.queueManager.CheckoutAsync<string>("worker-1", TimeSpan.FromMilliseconds(500));
         checkedOut.Should().NotBeNull();
 
         // Act - extend lease before expiry
         await Task.Delay(300);
-        await _leaseMonitor.ExtendLeaseAsync(messageId, TimeSpan.FromMinutes(1));
+        await this.leaseMonitor.ExtendLeaseAsync(messageId, TimeSpan.FromMinutes(1));
 
         // Wait past original expiry
         await Task.Delay(500);
 
         // Assert - message should still be checked out
-        var anotherCheckout = await _queueManager.CheckoutAsync<string>("worker-2");
+        var anotherCheckout = await this.queueManager.CheckoutAsync<string>("worker-2");
         anotherCheckout.Should().BeNull(); // No messages available
     }
 }

--- a/src/MessageQueue.Performance.Tests/CheckoutBenchmarks.cs
+++ b/src/MessageQueue.Performance.Tests/CheckoutBenchmarks.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="CheckoutBenchmarks.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using MessageQueue.Core;
@@ -14,9 +20,9 @@ namespace MessageQueue.Performance.Tests;
 [RankColumn]
 public class CheckoutBenchmarks
 {
-    private IQueueManager _queueManager = null!;
-    private ICircularBuffer _buffer = null!;
-    private DeduplicationIndex _deduplicationIndex = null!;
+    private IQueueManager queueManager = null!;
+    private ICircularBuffer buffer = null!;
+    private DeduplicationIndex deduplicationIndex = null!;
 
     [Params(1000, 10000)]
     public int MessageCount { get; set; }
@@ -32,9 +38,9 @@ public class CheckoutBenchmarks
             DefaultTimeout = TimeSpan.FromMinutes(5)
         };
 
-        _buffer = new CircularBuffer(options.Capacity);
-        _deduplicationIndex = new DeduplicationIndex();
-        _queueManager = new QueueManager(_buffer, _deduplicationIndex, options);
+        this.buffer = new CircularBuffer(options.Capacity);
+        this.deduplicationIndex = new DeduplicationIndex();
+        this.queueManager = new QueueManager(this.buffer, this.deduplicationIndex, options);
     }
 
     [IterationSetup]
@@ -43,7 +49,7 @@ public class CheckoutBenchmarks
         // Populate queue with messages
         for (int i = 0; i < MessageCount; i++)
         {
-            await _queueManager.EnqueueAsync(new TestMessage { Id = i, Data = $"Message {i}" });
+            await this.queueManager.EnqueueAsync(new TestMessage { Id = i, Data = $"Message {i}" });
         }
     }
 
@@ -52,10 +58,10 @@ public class CheckoutBenchmarks
     {
         for (int i = 0; i < MessageCount; i++)
         {
-            var message = await _queueManager.CheckoutAsync<TestMessage>("handler-1");
+            var message = await this.queueManager.CheckoutAsync<TestMessage>("handler-1");
             if (message != null)
             {
-                await _queueManager.AcknowledgeAsync(message.MessageId);
+                await this.queueManager.AcknowledgeAsync(message.MessageId);
             }
         }
     }
@@ -72,11 +78,11 @@ public class CheckoutBenchmarks
             {
                 while (true)
                 {
-                    var message = await _queueManager.CheckoutAsync<TestMessage>($"handler-{consumerId}");
+                    var message = await this.queueManager.CheckoutAsync<TestMessage>($"handler-{consumerId}");
                     if (message == null)
                         break;
 
-                    await _queueManager.AcknowledgeAsync(message.MessageId);
+                    await this.queueManager.AcknowledgeAsync(message.MessageId);
                 }
             }));
         }
@@ -89,12 +95,12 @@ public class CheckoutBenchmarks
     {
         for (int i = 0; i < Math.Min(MessageCount, 1000); i++)
         {
-            var message = await _queueManager.CheckoutAsync<TestMessage>("handler-1");
+            var message = await this.queueManager.CheckoutAsync<TestMessage>("handler-1");
             if (message != null)
             {
                 // Simulate processing with lease extension
-                await _queueManager.ExtendLeaseAsync(message.MessageId, TimeSpan.FromMinutes(1));
-                await _queueManager.AcknowledgeAsync(message.MessageId);
+                await this.queueManager.ExtendLeaseAsync(message.MessageId, TimeSpan.FromMinutes(1));
+                await this.queueManager.AcknowledgeAsync(message.MessageId);
             }
         }
     }

--- a/src/MessageQueue.Performance.Tests/EnqueueBenchmarks.cs
+++ b/src/MessageQueue.Performance.Tests/EnqueueBenchmarks.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="EnqueueBenchmarks.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using MessageQueue.Core;
@@ -14,9 +20,9 @@ namespace MessageQueue.Performance.Tests;
 [RankColumn]
 public class EnqueueBenchmarks
 {
-    private IQueueManager _queueManager = null!;
-    private ICircularBuffer _buffer = null!;
-    private DeduplicationIndex _deduplicationIndex = null!;
+    private IQueueManager queueManager = null!;
+    private ICircularBuffer buffer = null!;
+    private DeduplicationIndex deduplicationIndex = null!;
 
     [Params(1000, 10000, 100000)]
     public int MessageCount { get; set; }
@@ -31,9 +37,9 @@ public class EnqueueBenchmarks
             EnableDeduplication = true
         };
 
-        _buffer = new CircularBuffer(options.Capacity);
-        _deduplicationIndex = new DeduplicationIndex();
-        _queueManager = new QueueManager(_buffer, _deduplicationIndex, options);
+        this.buffer = new CircularBuffer(options.Capacity);
+        this.deduplicationIndex = new DeduplicationIndex();
+        this.queueManager = new QueueManager(this.buffer, this.deduplicationIndex, options);
     }
 
     [Benchmark(Description = "Enqueue without deduplication")]
@@ -41,7 +47,7 @@ public class EnqueueBenchmarks
     {
         for (int i = 0; i < MessageCount; i++)
         {
-            await _queueManager.EnqueueAsync(new TestMessage { Id = i, Data = $"Message {i}" });
+            await this.queueManager.EnqueueAsync(new TestMessage { Id = i, Data = $"Message {i}" });
         }
     }
 
@@ -50,7 +56,7 @@ public class EnqueueBenchmarks
     {
         for (int i = 0; i < MessageCount; i++)
         {
-            await _queueManager.EnqueueAsync(
+            await this.queueManager.EnqueueAsync(
                 new TestMessage { Id = i, Data = $"Message {i}" },
                 deduplicationKey: $"key-{i}");
         }
@@ -61,7 +67,7 @@ public class EnqueueBenchmarks
     {
         for (int i = 0; i < MessageCount; i++)
         {
-            await _queueManager.EnqueueAsync(
+            await this.queueManager.EnqueueAsync(
                 new TestMessage { Id = i, Data = $"Message {i}" },
                 deduplicationKey: $"key-{i % 100}"); // Repeat every 100 messages
         }
@@ -80,7 +86,7 @@ public class EnqueueBenchmarks
             {
                 for (int i = 0; i < messagesPerProducer; i++)
                 {
-                    await _queueManager.EnqueueAsync(
+                    await this.queueManager.EnqueueAsync(
                         new TestMessage { Id = producerId * messagesPerProducer + i, Data = $"Message {i}" });
                 }
             }));

--- a/src/MessageQueue.Performance.Tests/Program.cs
+++ b/src/MessageQueue.Performance.Tests/Program.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 

--- a/src/MessageQueue.Persistence.Tests/Integration/CrashRecoveryTests.cs
+++ b/src/MessageQueue.Persistence.Tests/Integration/CrashRecoveryTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="CrashRecoveryTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Persistence.Tests.Integration;
 
 using System;
@@ -15,21 +21,21 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class CrashRecoveryTests
 {
-    private string _testStoragePath = null!;
-    private PersistenceOptions _persistenceOptions = null!;
-    private QueueOptions _queueOptions = null!;
+    private string testStoragePath = null!;
+    private PersistenceOptions persistenceOptions = null!;
+    private QueueOptions queueOptions = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _testStoragePath = Path.Combine(Path.GetTempPath(), $"mq-recovery-test-{Guid.NewGuid()}");
-        _persistenceOptions = new PersistenceOptions
+        this.testStoragePath = Path.Combine(Path.GetTempPath(), $"mq-recovery-test-{Guid.NewGuid()}");
+        this.persistenceOptions = new PersistenceOptions
         {
-            StoragePath = _testStoragePath,
+            StoragePath = this.testStoragePath,
             SnapshotInterval = TimeSpan.FromMinutes(10),
             SnapshotThreshold = 5
         };
-        _queueOptions = new QueueOptions
+        this.queueOptions = new QueueOptions
         {
             Capacity = 100,
             DefaultTimeout = TimeSpan.FromMinutes(5)
@@ -39,11 +45,11 @@ public class CrashRecoveryTests
     [TestCleanup]
     public void Cleanup()
     {
-        if (Directory.Exists(_testStoragePath))
+        if (Directory.Exists(this.testStoragePath))
         {
             try
             {
-                Directory.Delete(_testStoragePath, recursive: true);
+                Directory.Delete(this.testStoragePath, recursive: true);
             }
             catch
             {
@@ -56,10 +62,10 @@ public class CrashRecoveryTests
     public async Task Recovery_AfterSnapshot_RestoresAllMessages()
     {
         // Arrange - Create and persist queue state
-        var buffer1 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer1 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup1 = new DeduplicationIndex();
-        var persister1 = new FilePersister(_persistenceOptions);
-        var queueManager1 = new QueueManager(buffer1, dedup1, _queueOptions, persister1);
+        var persister1 = new FilePersister(this.persistenceOptions);
+        var queueManager1 = new QueueManager(buffer1, dedup1, this.queueOptions, persister1);
 
         // Enqueue messages
         await queueManager1.EnqueueAsync("Message 1");
@@ -73,9 +79,9 @@ public class CrashRecoveryTests
         persister1.Dispose();
 
         // Act - Recover from snapshot
-        var buffer2 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer2 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup2 = new DeduplicationIndex();
-        var persister2 = new FilePersister(_persistenceOptions);
+        var persister2 = new FilePersister(this.persistenceOptions);
         var recovery = new RecoveryService(persister2, buffer2, dedup2);
 
         var result = await recovery.RecoverAsync();
@@ -96,10 +102,10 @@ public class CrashRecoveryTests
     public async Task Recovery_WithJournalReplay_RestoresCorrectState()
     {
         // Arrange - Create queue and write operations
-        var buffer1 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer1 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup1 = new DeduplicationIndex();
-        var persister1 = new FilePersister(_persistenceOptions);
-        var queueManager1 = new QueueManager(buffer1, dedup1, _queueOptions, persister1);
+        var persister1 = new FilePersister(this.persistenceOptions);
+        var queueManager1 = new QueueManager(buffer1, dedup1, this.queueOptions, persister1);
 
         // Enqueue 5 messages
         var msgId1 = await queueManager1.EnqueueAsync("Message 1");
@@ -122,9 +128,9 @@ public class CrashRecoveryTests
         persister1.Dispose();
 
         // Act - Recover
-        var buffer2 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer2 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup2 = new DeduplicationIndex();
-        var persister2 = new FilePersister(_persistenceOptions);
+        var persister2 = new FilePersister(this.persistenceOptions);
         var recovery = new RecoveryService(persister2, buffer2, dedup2);
 
         var result = await recovery.RecoverAsync();
@@ -148,10 +154,10 @@ public class CrashRecoveryTests
     public async Task Recovery_WithExpiredLeases_RequeulesMessages()
     {
         // Arrange - Create queue with checked-out message
-        var buffer1 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer1 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup1 = new DeduplicationIndex();
-        var persister1 = new FilePersister(_persistenceOptions);
-        var queueManager1 = new QueueManager(buffer1, dedup1, _queueOptions, persister1);
+        var persister1 = new FilePersister(this.persistenceOptions);
+        var queueManager1 = new QueueManager(buffer1, dedup1, this.queueOptions, persister1);
 
         // Enqueue and checkout message
         await queueManager1.EnqueueAsync("Message 1");
@@ -168,9 +174,9 @@ public class CrashRecoveryTests
         persister1.Dispose();
 
         // Act - Recover
-        var buffer2 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer2 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup2 = new DeduplicationIndex();
-        var persister2 = new FilePersister(_persistenceOptions);
+        var persister2 = new FilePersister(this.persistenceOptions);
         var recovery = new RecoveryService(persister2, buffer2, dedup2);
 
         await recovery.RecoverAsync();
@@ -190,10 +196,10 @@ public class CrashRecoveryTests
     public async Task Recovery_WithDeduplication_RestoresIndex()
     {
         // Arrange - Create queue with deduplicated messages
-        var buffer1 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer1 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup1 = new DeduplicationIndex();
-        var persister1 = new FilePersister(_persistenceOptions);
-        var queueManager1 = new QueueManager(buffer1, dedup1, _queueOptions, persister1);
+        var persister1 = new FilePersister(this.persistenceOptions);
+        var queueManager1 = new QueueManager(buffer1, dedup1, this.queueOptions, persister1);
 
         // Enqueue messages with dedup keys
         await queueManager1.EnqueueAsync("Message 1", "key-1");
@@ -207,9 +213,9 @@ public class CrashRecoveryTests
         persister1.Dispose();
 
         // Act - Recover
-        var buffer2 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer2 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup2 = new DeduplicationIndex();
-        var persister2 = new FilePersister(_persistenceOptions);
+        var persister2 = new FilePersister(this.persistenceOptions);
         var recovery = new RecoveryService(persister2, buffer2, dedup2);
 
         var result = await recovery.RecoverAsync();
@@ -220,7 +226,7 @@ public class CrashRecoveryTests
         result.DeduplicationEntriesRestored.Should().Be(3);
 
         // Verify dedup index works - duplicate should supersede existing Ready message
-        var queueManager2 = new QueueManager(buffer2, dedup2, _queueOptions, persister2);
+        var queueManager2 = new QueueManager(buffer2, dedup2, this.queueOptions, persister2);
         var dupMsgId = await queueManager2.EnqueueAsync("Duplicate", "key-1");
 
         // Should supersede existing message - verify new message is present and old is superseded
@@ -237,9 +243,9 @@ public class CrashRecoveryTests
     public async Task Recovery_WithNoPersistedData_StartsClean()
     {
         // Arrange
-        var buffer = new CircularBuffer(_queueOptions.Capacity);
+        var buffer = new CircularBuffer(this.queueOptions.Capacity);
         var dedup = new DeduplicationIndex();
-        var persister = new FilePersister(_persistenceOptions);
+        var persister = new FilePersister(this.persistenceOptions);
         var recovery = new RecoveryService(persister, buffer, dedup);
 
         // Act
@@ -262,10 +268,10 @@ public class CrashRecoveryTests
     public async Task FullScenario_EnqueueSnapshotCrashRecover_WorksEndToEnd()
     {
         // Arrange - Phase 1: Normal operation
-        var buffer1 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer1 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup1 = new DeduplicationIndex();
-        var persister1 = new FilePersister(_persistenceOptions);
-        var queueManager1 = new QueueManager(buffer1, dedup1, _queueOptions, persister1);
+        var persister1 = new FilePersister(this.persistenceOptions);
+        var queueManager1 = new QueueManager(buffer1, dedup1, this.queueOptions, persister1);
 
         // Enqueue 10 messages
         for (int i = 1; i <= 10; i++)
@@ -290,9 +296,9 @@ public class CrashRecoveryTests
         persister1.Dispose();
 
         // Act - Phase 2: Simulated crash and recovery
-        var buffer2 = new CircularBuffer(_queueOptions.Capacity);
+        var buffer2 = new CircularBuffer(this.queueOptions.Capacity);
         var dedup2 = new DeduplicationIndex();
-        var persister2 = new FilePersister(_persistenceOptions);
+        var persister2 = new FilePersister(this.persistenceOptions);
         var recovery = new RecoveryService(persister2, buffer2, dedup2);
 
         var result = await recovery.RecoverAsync();
@@ -306,7 +312,7 @@ public class CrashRecoveryTests
         count.Should().BeGreaterOrEqualTo(8); // 10 - 2 acknowledged = 8, plus any journal replays
 
         // Create new queue manager and verify operations work
-        var queueManager2 = new QueueManager(buffer2, dedup2, _queueOptions, persister2);
+        var queueManager2 = new QueueManager(buffer2, dedup2, this.queueOptions, persister2);
 
         // Should be able to enqueue new message
         var newMsgId = await queueManager2.EnqueueAsync("New Message", "key-new");

--- a/src/MessageQueue.Persistence.Tests/Unit/FilePersisterTests.cs
+++ b/src/MessageQueue.Persistence.Tests/Unit/FilePersisterTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="FilePersisterTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Persistence.Tests.Unit;
 
 using System;
@@ -13,16 +19,16 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class FilePersisterTests
 {
-    private string _testStoragePath = null!;
-    private PersistenceOptions _options = null!;
+    private string testStoragePath = null!;
+    private PersistenceOptions options = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _testStoragePath = Path.Combine(Path.GetTempPath(), $"mq-test-{Guid.NewGuid()}");
-        _options = new PersistenceOptions
+        this.testStoragePath = Path.Combine(Path.GetTempPath(), $"mq-test-{Guid.NewGuid()}");
+        this.options = new PersistenceOptions
         {
-            StoragePath = _testStoragePath,
+            StoragePath = this.testStoragePath,
             SnapshotInterval = TimeSpan.FromMinutes(5),
             SnapshotThreshold = 10
         };
@@ -31,11 +37,11 @@ public class FilePersisterTests
     [TestCleanup]
     public void Cleanup()
     {
-        if (Directory.Exists(_testStoragePath))
+        if (Directory.Exists(this.testStoragePath))
         {
             try
             {
-                Directory.Delete(_testStoragePath, recursive: true);
+                Directory.Delete(this.testStoragePath, recursive: true);
             }
             catch
             {
@@ -48,10 +54,10 @@ public class FilePersisterTests
     public void Constructor_CreatesStorageDirectory()
     {
         // Act
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
 
         // Assert
-        Directory.Exists(_testStoragePath).Should().BeTrue();
+        Directory.Exists(this.testStoragePath).Should().BeTrue();
     }
 
     [TestMethod]
@@ -65,14 +71,14 @@ public class FilePersisterTests
     public async Task WriteOperationAsync_CreatesJournalFile()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
         var operation = CreateTestOperation();
 
         // Act
         await persister.WriteOperationAsync(operation);
 
         // Assert
-        var journalPath = Path.Combine(_testStoragePath, "journal.dat");
+        var journalPath = Path.Combine(this.testStoragePath, "journal.dat");
         File.Exists(journalPath).Should().BeTrue();
     }
 
@@ -80,7 +86,7 @@ public class FilePersisterTests
     public async Task WriteOperationAsync_WithNullOperation_ThrowsArgumentNullException()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
 
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
@@ -91,14 +97,14 @@ public class FilePersisterTests
     public async Task CreateSnapshotAsync_CreatesSnapshotFile()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
         var snapshot = CreateTestSnapshot();
 
         // Act
         await persister.CreateSnapshotAsync(snapshot);
 
         // Assert
-        var snapshotPath = Path.Combine(_testStoragePath, "snapshot.dat");
+        var snapshotPath = Path.Combine(this.testStoragePath, "snapshot.dat");
         File.Exists(snapshotPath).Should().BeTrue();
     }
 
@@ -106,7 +112,7 @@ public class FilePersisterTests
     public async Task CreateSnapshotAsync_WithNullSnapshot_ThrowsArgumentNullException()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
 
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
@@ -117,7 +123,7 @@ public class FilePersisterTests
     public async Task LoadSnapshotAsync_WithNoSnapshot_ReturnsNull()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
 
         // Act
         var snapshot = await persister.LoadSnapshotAsync();
@@ -130,7 +136,7 @@ public class FilePersisterTests
     public async Task LoadSnapshotAsync_AfterCreate_ReturnsSnapshot()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
         var original = CreateTestSnapshot();
         await persister.CreateSnapshotAsync(original);
 
@@ -148,7 +154,7 @@ public class FilePersisterTests
     public async Task ReplayJournalAsync_WithNoJournal_ReturnsEmptyList()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
 
         // Act
         var operations = await persister.ReplayJournalAsync(0);
@@ -161,7 +167,7 @@ public class FilePersisterTests
     public async Task ReplayJournalAsync_AfterWrites_ReturnsOperations()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
         var op1 = CreateTestOperation(1, OperationCode.Enqueue);
         var op2 = CreateTestOperation(2, OperationCode.Checkout);
         var op3 = CreateTestOperation(3, OperationCode.Acknowledge);
@@ -185,7 +191,7 @@ public class FilePersisterTests
     public async Task ReplayJournalAsync_WithSinceVersion_ReturnsOnlyNewer()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
         var op1 = CreateTestOperation(1, OperationCode.Enqueue);
         var op2 = CreateTestOperation(2, OperationCode.Checkout);
         var op3 = CreateTestOperation(3, OperationCode.Acknowledge);
@@ -208,7 +214,7 @@ public class FilePersisterTests
     public async Task TruncateJournalAsync_RemovesOldOperations()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
         var op1 = CreateTestOperation(1, OperationCode.Enqueue);
         var op2 = CreateTestOperation(2, OperationCode.Checkout);
         var op3 = CreateTestOperation(3, OperationCode.Acknowledge);
@@ -231,7 +237,7 @@ public class FilePersisterTests
     public void ShouldSnapshot_InitiallyReturnsFalse()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
 
         // Act
         var should = persister.ShouldSnapshot();
@@ -244,8 +250,8 @@ public class FilePersisterTests
     public async Task ShouldSnapshot_AfterThresholdOperations_ReturnsTrue()
     {
         // Arrange
-        _options.SnapshotThreshold = 5;
-        using var persister = new FilePersister(_options);
+        this.options.SnapshotThreshold = 5;
+        using var persister = new FilePersister(this.options);
 
         // Write 5 operations
         for (int i = 1; i <= 5; i++)
@@ -264,8 +270,8 @@ public class FilePersisterTests
     public async Task ShouldSnapshot_AfterSnapshotInterval_ReturnsTrue()
     {
         // Arrange
-        _options.SnapshotInterval = TimeSpan.FromMilliseconds(100);
-        using var persister = new FilePersister(_options);
+        this.options.SnapshotInterval = TimeSpan.FromMilliseconds(100);
+        using var persister = new FilePersister(this.options);
 
         // Wait for interval to pass
         await Task.Delay(150);
@@ -281,8 +287,8 @@ public class FilePersisterTests
     public async Task ShouldSnapshot_AfterSnapshot_ResetsCounter()
     {
         // Arrange
-        _options.SnapshotThreshold = 5;
-        using var persister = new FilePersister(_options);
+        this.options.SnapshotThreshold = 5;
+        using var persister = new FilePersister(this.options);
 
         // Write 5 operations
         for (int i = 1; i <= 5; i++)
@@ -304,7 +310,7 @@ public class FilePersisterTests
     public async Task CreateSnapshot_OverwritesPreviousSnapshot()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
         var snapshot1 = CreateTestSnapshot();
         snapshot1.Version = 1;
         await persister.CreateSnapshotAsync(snapshot1);
@@ -325,7 +331,7 @@ public class FilePersisterTests
     public async Task MultipleOperations_CanBeReplayedInOrder()
     {
         // Arrange
-        using var persister = new FilePersister(_options);
+        using var persister = new FilePersister(this.options);
 
         // Write operations in order
         for (int i = 1; i <= 20; i++)

--- a/src/MessageQueue.Persistence.Tests/Unit/JournalSerializerTests.cs
+++ b/src/MessageQueue.Persistence.Tests/Unit/JournalSerializerTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="JournalSerializerTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Persistence.Tests.Unit;
 
 using System;
@@ -12,12 +18,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class JournalSerializerTests
 {
-    private JournalSerializer _serializer = null!;
+    private JournalSerializer serializer = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _serializer = new JournalSerializer();
+        this.serializer = new JournalSerializer();
     }
 
     [TestMethod]
@@ -27,7 +33,7 @@ public class JournalSerializerTests
         var record = CreateTestRecord();
 
         // Act
-        var result = await _serializer.SerializeAsync(record);
+        var result = await this.serializer.SerializeAsync(record);
 
         // Assert
         result.Should().NotBeNull();
@@ -39,7 +45,7 @@ public class JournalSerializerTests
     {
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
-            async () => await _serializer.SerializeAsync(null!));
+            async () => await this.serializer.SerializeAsync(null!));
     }
 
     [TestMethod]
@@ -47,10 +53,10 @@ public class JournalSerializerTests
     {
         // Arrange
         var original = CreateTestRecord();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Act
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.Should().NotBeNull();
@@ -66,7 +72,7 @@ public class JournalSerializerTests
     {
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
-            async () => await _serializer.DeserializeAsync(null!));
+            async () => await this.serializer.DeserializeAsync(null!));
     }
 
     [TestMethod]
@@ -77,7 +83,7 @@ public class JournalSerializerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<ArgumentException>(
-            async () => await _serializer.DeserializeAsync(shortData));
+            async () => await this.serializer.DeserializeAsync(shortData));
         exception.Message.Should().Contain("too short");
     }
 
@@ -86,14 +92,14 @@ public class JournalSerializerTests
     {
         // Arrange
         var original = CreateTestRecord();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Corrupt the CRC (bytes 12-15 in header)
         serialized[12] ^= 0xFF;
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.DeserializeAsync(serialized));
+            async () => await this.serializer.DeserializeAsync(serialized));
         exception.Message.Should().Contain("CRC mismatch");
     }
 
@@ -102,14 +108,14 @@ public class JournalSerializerTests
     {
         // Arrange
         var original = CreateTestRecord();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Corrupt the payload (after header)
         serialized[20] ^= 0xFF;
 
         // Act & Assert
         await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.DeserializeAsync(serialized));
+            async () => await this.serializer.DeserializeAsync(serialized));
     }
 
     [TestMethod]
@@ -117,7 +123,7 @@ public class JournalSerializerTests
     {
         // Arrange
         var original = CreateTestRecord();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Corrupt the payload length (bytes 8-11 in header) to be larger than actual data
         var corruptedLength = BitConverter.GetBytes(serialized.Length * 2);
@@ -125,7 +131,7 @@ public class JournalSerializerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.DeserializeAsync(serialized));
+            async () => await this.serializer.DeserializeAsync(serialized));
         exception.Message.Should().Contain("does not match payload length");
     }
 
@@ -135,10 +141,10 @@ public class JournalSerializerTests
         // Arrange
         var record = CreateTestRecord();
         record.SequenceNumber = 42;
-        var serialized = await _serializer.SerializeAsync(record);
+        var serialized = await this.serializer.SerializeAsync(record);
 
         // Act
-        var sequenceNumber = await _serializer.ReadSequenceNumberAsync(serialized);
+        var sequenceNumber = await this.serializer.ReadSequenceNumberAsync(serialized);
 
         // Assert
         sequenceNumber.Should().Be(42);
@@ -149,7 +155,7 @@ public class JournalSerializerTests
     {
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
-            async () => await _serializer.ReadSequenceNumberAsync(null!));
+            async () => await this.serializer.ReadSequenceNumberAsync(null!));
     }
 
     [TestMethod]
@@ -160,7 +166,7 @@ public class JournalSerializerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<ArgumentException>(
-            async () => await _serializer.ReadSequenceNumberAsync(shortData));
+            async () => await this.serializer.ReadSequenceNumberAsync(shortData));
         exception.Message.Should().Contain("too short");
     }
 
@@ -169,10 +175,10 @@ public class JournalSerializerTests
     {
         // Arrange
         var record = CreateTestRecord();
-        var serialized = await _serializer.SerializeAsync(record);
+        var serialized = await this.serializer.SerializeAsync(record);
 
         // Act
-        var recordSize = await _serializer.ReadRecordSizeAsync(serialized);
+        var recordSize = await this.serializer.ReadRecordSizeAsync(serialized);
 
         // Assert
         recordSize.Should().Be(serialized.Length);
@@ -183,7 +189,7 @@ public class JournalSerializerTests
     {
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
-            async () => await _serializer.ReadRecordSizeAsync(null!));
+            async () => await this.serializer.ReadRecordSizeAsync(null!));
     }
 
     [TestMethod]
@@ -194,7 +200,7 @@ public class JournalSerializerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<ArgumentException>(
-            async () => await _serializer.ReadRecordSizeAsync(shortData));
+            async () => await this.serializer.ReadRecordSizeAsync(shortData));
         exception.Message.Should().Contain("too short");
     }
 
@@ -209,8 +215,8 @@ public class JournalSerializerTests
             record.OperationCode = opCode;
 
             // Act
-            var serialized = await _serializer.SerializeAsync(record);
-            var deserialized = await _serializer.DeserializeAsync(serialized);
+            var serialized = await this.serializer.SerializeAsync(record);
+            var deserialized = await this.serializer.DeserializeAsync(serialized);
 
             // Assert
             deserialized.OperationCode.Should().Be(opCode);
@@ -225,8 +231,8 @@ public class JournalSerializerTests
         record.Payload = new string('X', 10000); // Large payload
 
         // Act
-        var serialized = await _serializer.SerializeAsync(record);
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var serialized = await this.serializer.SerializeAsync(record);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.Payload.Should().Be(record.Payload);
@@ -241,8 +247,8 @@ public class JournalSerializerTests
         record.Payload = string.Empty;
 
         // Act
-        var serialized = await _serializer.SerializeAsync(record);
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var serialized = await this.serializer.SerializeAsync(record);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.Payload.Should().BeEmpty();
@@ -256,8 +262,8 @@ public class JournalSerializerTests
         record.Payload = "{\"test\":\"こんにちは\",\"emoji\":\"🤖\",\"special\":\"\\n\\t\\\"\"}";
 
         // Act
-        var serialized = await _serializer.SerializeAsync(record);
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var serialized = await this.serializer.SerializeAsync(record);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.Payload.Should().Be(record.Payload);
@@ -280,13 +286,13 @@ public class JournalSerializerTests
         record3.OperationCode = OperationCode.Acknowledge;
 
         // Act
-        var serialized1 = await _serializer.SerializeAsync(record1);
-        var serialized2 = await _serializer.SerializeAsync(record2);
-        var serialized3 = await _serializer.SerializeAsync(record3);
+        var serialized1 = await this.serializer.SerializeAsync(record1);
+        var serialized2 = await this.serializer.SerializeAsync(record2);
+        var serialized3 = await this.serializer.SerializeAsync(record3);
 
-        var deserialized1 = await _serializer.DeserializeAsync(serialized1);
-        var deserialized2 = await _serializer.DeserializeAsync(serialized2);
-        var deserialized3 = await _serializer.DeserializeAsync(serialized3);
+        var deserialized1 = await this.serializer.DeserializeAsync(serialized1);
+        var deserialized2 = await this.serializer.DeserializeAsync(serialized2);
+        var deserialized3 = await this.serializer.DeserializeAsync(serialized3);
 
         // Assert
         deserialized1.SequenceNumber.Should().Be(1);

--- a/src/MessageQueue.Persistence.Tests/Unit/SnapshotSerializerTests.cs
+++ b/src/MessageQueue.Persistence.Tests/Unit/SnapshotSerializerTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="SnapshotSerializerTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Persistence.Tests.Unit;
 
 using System;
@@ -13,12 +19,12 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 [TestClass]
 public class SnapshotSerializerTests
 {
-    private SnapshotSerializer _serializer = null!;
+    private SnapshotSerializer serializer = null!;
 
     [TestInitialize]
     public void Setup()
     {
-        _serializer = new SnapshotSerializer();
+        this.serializer = new SnapshotSerializer();
     }
 
     [TestMethod]
@@ -28,7 +34,7 @@ public class SnapshotSerializerTests
         var snapshot = CreateTestSnapshot();
 
         // Act
-        var result = await _serializer.SerializeAsync(snapshot);
+        var result = await this.serializer.SerializeAsync(snapshot);
 
         // Assert
         result.Should().NotBeNull();
@@ -40,7 +46,7 @@ public class SnapshotSerializerTests
     {
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
-            async () => await _serializer.SerializeAsync(null!));
+            async () => await this.serializer.SerializeAsync(null!));
     }
 
     [TestMethod]
@@ -48,10 +54,10 @@ public class SnapshotSerializerTests
     {
         // Arrange
         var original = CreateTestSnapshot();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Act
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.Should().NotBeNull();
@@ -67,7 +73,7 @@ public class SnapshotSerializerTests
     {
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
-            async () => await _serializer.DeserializeAsync(null!));
+            async () => await this.serializer.DeserializeAsync(null!));
     }
 
     [TestMethod]
@@ -78,7 +84,7 @@ public class SnapshotSerializerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.DeserializeAsync(shortData));
+            async () => await this.serializer.DeserializeAsync(shortData));
         exception.Message.Should().Contain("too short");
     }
 
@@ -87,14 +93,14 @@ public class SnapshotSerializerTests
     {
         // Arrange
         var original = CreateTestSnapshot();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Corrupt the magic number (first 8 bytes)
         serialized[0] ^= 0xFF;
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.DeserializeAsync(serialized));
+            async () => await this.serializer.DeserializeAsync(serialized));
         exception.Message.Should().Contain("Invalid magic number");
     }
 
@@ -103,14 +109,14 @@ public class SnapshotSerializerTests
     {
         // Arrange
         var original = CreateTestSnapshot();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Corrupt the CRC (bytes 20-23 in header)
         serialized[20] ^= 0xFF;
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.DeserializeAsync(serialized));
+            async () => await this.serializer.DeserializeAsync(serialized));
         exception.Message.Should().Contain("CRC mismatch");
     }
 
@@ -119,14 +125,14 @@ public class SnapshotSerializerTests
     {
         // Arrange
         var original = CreateTestSnapshot();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Corrupt the payload (after header)
         serialized[30] ^= 0xFF;
 
         // Act & Assert
         await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.DeserializeAsync(serialized));
+            async () => await this.serializer.DeserializeAsync(serialized));
     }
 
     [TestMethod]
@@ -134,7 +140,7 @@ public class SnapshotSerializerTests
     {
         // Arrange
         var original = CreateTestSnapshot();
-        var serialized = await _serializer.SerializeAsync(original);
+        var serialized = await this.serializer.SerializeAsync(original);
 
         // Corrupt the version in header (bytes 8-15)
         var corruptedVersion = BitConverter.GetBytes(999L);
@@ -145,7 +151,7 @@ public class SnapshotSerializerTests
 
         // Act & Assert
         await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.DeserializeAsync(serialized));
+            async () => await this.serializer.DeserializeAsync(serialized));
     }
 
     [TestMethod]
@@ -154,10 +160,10 @@ public class SnapshotSerializerTests
         // Arrange
         var snapshot = CreateTestSnapshot();
         snapshot.Version = 42;
-        var serialized = await _serializer.SerializeAsync(snapshot);
+        var serialized = await this.serializer.SerializeAsync(snapshot);
 
         // Act
-        var version = await _serializer.ReadVersionAsync(serialized);
+        var version = await this.serializer.ReadVersionAsync(serialized);
 
         // Assert
         version.Should().Be(42);
@@ -168,7 +174,7 @@ public class SnapshotSerializerTests
     {
         // Act & Assert
         await Assert.ThrowsExceptionAsync<ArgumentNullException>(
-            async () => await _serializer.ReadVersionAsync(null!));
+            async () => await this.serializer.ReadVersionAsync(null!));
     }
 
     [TestMethod]
@@ -179,7 +185,7 @@ public class SnapshotSerializerTests
 
         // Act & Assert
         var exception = await Assert.ThrowsExceptionAsync<ArgumentException>(
-            async () => await _serializer.ReadVersionAsync(shortData));
+            async () => await this.serializer.ReadVersionAsync(shortData));
         exception.Message.Should().Contain("too short");
     }
 
@@ -193,7 +199,7 @@ public class SnapshotSerializerTests
 
         // Act & Assert
         await Assert.ThrowsExceptionAsync<InvalidDataException>(
-            async () => await _serializer.ReadVersionAsync(data));
+            async () => await this.serializer.ReadVersionAsync(data));
     }
 
     [TestMethod]
@@ -201,10 +207,10 @@ public class SnapshotSerializerTests
     {
         // Arrange
         var snapshot = CreateTestSnapshot();
-        var serialized = await _serializer.SerializeAsync(snapshot);
+        var serialized = await this.serializer.SerializeAsync(snapshot);
 
         // Act
-        var isValid = await _serializer.ValidateHeaderAsync(serialized);
+        var isValid = await this.serializer.ValidateHeaderAsync(serialized);
 
         // Assert
         isValid.Should().BeTrue();
@@ -214,7 +220,7 @@ public class SnapshotSerializerTests
     public async Task ValidateHeaderAsync_WithNullData_ReturnsFalse()
     {
         // Act
-        var isValid = await _serializer.ValidateHeaderAsync(null!);
+        var isValid = await this.serializer.ValidateHeaderAsync(null!);
 
         // Assert
         isValid.Should().BeFalse();
@@ -227,7 +233,7 @@ public class SnapshotSerializerTests
         var shortData = new byte[10];
 
         // Act
-        var isValid = await _serializer.ValidateHeaderAsync(shortData);
+        var isValid = await this.serializer.ValidateHeaderAsync(shortData);
 
         // Assert
         isValid.Should().BeFalse();
@@ -238,11 +244,11 @@ public class SnapshotSerializerTests
     {
         // Arrange
         var snapshot = CreateTestSnapshot();
-        var serialized = await _serializer.SerializeAsync(snapshot);
+        var serialized = await this.serializer.SerializeAsync(snapshot);
         serialized[0] ^= 0xFF; // Corrupt magic
 
         // Act
-        var isValid = await _serializer.ValidateHeaderAsync(serialized);
+        var isValid = await this.serializer.ValidateHeaderAsync(serialized);
 
         // Assert
         isValid.Should().BeFalse();
@@ -264,8 +270,8 @@ public class SnapshotSerializerTests
         };
 
         // Act
-        var serialized = await _serializer.SerializeAsync(snapshot);
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var serialized = await this.serializer.SerializeAsync(snapshot);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.MessageCount.Should().Be(0);
@@ -286,8 +292,8 @@ public class SnapshotSerializerTests
         snapshot.MessageCount = 3;
 
         // Act
-        var serialized = await _serializer.SerializeAsync(snapshot);
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var serialized = await this.serializer.SerializeAsync(snapshot);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.Messages.Should().HaveCount(3);
@@ -313,8 +319,8 @@ public class SnapshotSerializerTests
         };
 
         // Act
-        var serialized = await _serializer.SerializeAsync(snapshot);
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var serialized = await this.serializer.SerializeAsync(snapshot);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.DeduplicationIndex.Should().HaveCount(3);
@@ -337,8 +343,8 @@ public class SnapshotSerializerTests
         snapshot.MessageCount = 100;
 
         // Act
-        var serialized = await _serializer.SerializeAsync(snapshot);
-        var deserialized = await _serializer.DeserializeAsync(serialized);
+        var serialized = await this.serializer.SerializeAsync(snapshot);
+        var deserialized = await this.serializer.DeserializeAsync(serialized);
 
         // Assert
         deserialized.Messages.Should().HaveCount(100);

--- a/src/MessageQueue.Persistence/RecoveryService.cs
+++ b/src/MessageQueue.Persistence/RecoveryService.cs
@@ -332,7 +332,7 @@ namespace MessageQueue.Persistence
         public long LastVersion { get; set; }
 
         /// <summary>
-        /// Duration of recovery
+        /// this.Duration of recovery
         /// </summary>
         public TimeSpan Duration => this.EndTime - this.StartTime;
     }

--- a/src/MessageQueue.Persistence/Serialization/JournalSerializer.cs
+++ b/src/MessageQueue.Persistence/Serialization/JournalSerializer.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="JournalSerializer.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Persistence.Serialization;
 
 using System;

--- a/src/samples/MessageQueue.Samples.Advanced/Program.cs
+++ b/src/samples/MessageQueue.Samples.Advanced/Program.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Samples.Advanced;
 
 /// <summary>

--- a/src/samples/MessageQueue.Samples.Basic/Program.cs
+++ b/src/samples/MessageQueue.Samples.Basic/Program.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 namespace MessageQueue.Samples.Basic;
 
 /// <summary>

--- a/tests/MessageQueue.ChaosTests/HandlerCrashTests.cs
+++ b/tests/MessageQueue.ChaosTests/HandlerCrashTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="HandlerCrashTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 using FluentAssertions;
 using MessageQueue.Core;
 using MessageQueue.Core.Interfaces;

--- a/tests/MessageQueue.ChaosTests/PersistenceFailureTests.cs
+++ b/tests/MessageQueue.ChaosTests/PersistenceFailureTests.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="PersistenceFailureTests.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 using FluentAssertions;
 using MessageQueue.Core;
 using MessageQueue.Core.Enums;

--- a/tests/MessageQueue.SoakTests/Program.cs
+++ b/tests/MessageQueue.SoakTests/Program.cs
@@ -1,3 +1,9 @@
+// -----------------------------------------------------------------------
+// <copyright file="Program.cs" company="Microsoft Corp.">
+//     Copyright (c) Microsoft Corp. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 using MessageQueue.Core;
 using MessageQueue.Core.Interfaces;
 using MessageQueue.Core.Options;
@@ -13,10 +19,10 @@ namespace MessageQueue.SoakTests;
 /// </summary>
 public class Program
 {
-    private static long _totalEnqueued = 0;
-    private static long _totalProcessed = 0;
-    private static long _totalFailed = 0;
-    private static readonly object _statsLock = new object();
+    private static long TotalEnqueued = 0;
+    private static long TotalProcessed = 0;
+    private static long TotalFailed = 0;
+    private static readonly object StatsLock = new object();
 
     public static async Task Main(string[] args)
     {
@@ -143,12 +149,12 @@ public class Program
 
         // Final stats
         Log.Information("=== Final Statistics ===");
-        Log.Information("Total Enqueued: {TotalEnqueued}", _totalEnqueued);
-        Log.Information("Total Processed: {TotalProcessed}", _totalProcessed);
-        Log.Information("Total Failed: {TotalFailed}", _totalFailed);
-        Log.Information("Success Rate: {SuccessRate:P2}", (double)_totalProcessed / _totalEnqueued);
+        Log.Information("Total Enqueued: {TotalEnqueued}", TotalEnqueued);
+        Log.Information("Total Processed: {TotalProcessed}", TotalProcessed);
+        Log.Information("Total Failed: {TotalFailed}", TotalFailed);
+        Log.Information("Success Rate: {SuccessRate:P2}", (double)TotalProcessed / TotalEnqueued);
         Log.Information("Duration: {Duration}", stopwatch.Elapsed);
-        Log.Information("Throughput: {Throughput:F2} msg/sec", _totalProcessed / stopwatch.Elapsed.TotalSeconds);
+        Log.Information("Throughput: {Throughput:F2} msg/sec", TotalProcessed / stopwatch.Elapsed.TotalSeconds);
 
         // Cleanup
         serviceProvider.Dispose();
@@ -178,7 +184,7 @@ public class Program
                 await queueManager.EnqueueAsync(message);
                 dispatcher.SignalMessageReady(typeof(WorkMessage));
 
-                Interlocked.Increment(ref _totalEnqueued);
+                Interlocked.Increment(ref TotalEnqueued);
 
                 // Throttle production rate
                 await Task.Delay(random.Next(50, 200), cancellationToken);
@@ -205,9 +211,9 @@ public class Program
             {
                 await Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
 
-                var enqueued = Interlocked.Read(ref _totalEnqueued);
-                var processed = Interlocked.Read(ref _totalProcessed);
-                var failed = Interlocked.Read(ref _totalFailed);
+                var enqueued = Interlocked.Read(ref TotalEnqueued);
+                var processed = Interlocked.Read(ref TotalProcessed);
+                var failed = Interlocked.Read(ref TotalFailed);
 
                 Log.Information(
                     "[{Elapsed}] Stats: Enqueued={Enqueued}, Processed={Processed}, Failed={Failed}, Rate={Rate:F2} msg/s",
@@ -243,12 +249,12 @@ public class Program
             // Simulate work
             await Task.Delay(message.ProcessingTimeMs, cancellationToken);
 
-            Interlocked.Increment(ref _totalProcessed);
+            Interlocked.Increment(ref TotalProcessed);
 
             // Simulate occasional failures (5% failure rate)
             if (Random.Shared.Next(100) < 5)
             {
-                Interlocked.Increment(ref _totalFailed);
+                Interlocked.Increment(ref TotalFailed);
                 throw new Exception("Simulated handler failure");
             }
         }


### PR DESCRIPTION
## Summary
- add the required Microsoft header comment block to every C# source and test file
- rename private instance fields to camelCase, rename static fields to PascalCase, and qualify member access with `this.` per editorconfig naming rules
- update tests, samples, and infrastructure code so their usage sites follow the new naming and qualification conventions

## Testing
- not run (dotnet CLI not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4c84dacfc832daf017c93305f246d