### PR TITLE
Add Nerdbank.GitVersioning and publish package in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: .NET Build and Test
+name: Build, Test, and Publish Package
 
 on:
   push:
@@ -47,11 +47,16 @@ jobs:
         run: echo "No test projects found. Skipping tests."
 
       - name: Pack NuGet package
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: dotnet pack src/MessageQueue.Core/MessageQueue.Core.csproj --configuration Release --no-build --output ./artifacts
+        run: dotnet pack src/MessageQueue.Core/MessageQueue.Core.csproj --configuration Release --no-build --output ./artifacts -p:ContinuousIntegrationBuild=true
+
+      - name: Upload NuGet artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: artifacts/*.nupkg
 
       - name: Publish NuGet package
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,8 +14,6 @@
     <Product>MQ</Product>
     <Company>AzureStack Compute</Company>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
 
     <!-- Central package management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
@@ -37,6 +35,10 @@
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(OS)' != 'Windows_NT'">
     <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageReference Include="coverlet.collector" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Versioning -->
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.139" />
     <!-- OpenTelemetry -->
     <PackageVersion Include="OpenTelemetry" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.9.0" />

--- a/version.json
+++ b/version.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.5",
+  "assemblyVersion": {
+    "version": "0.5",
+    "precision": "revision"
+  },
+  "nugetPackageVersion": {
+    "semVer": 2,
+    "precision": "build"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$",
+    "^refs/heads/release/",
+    "^refs/tags/v\\d+\\.\\d+\\.\\d+$"
+  ],
+  "cloudBuild": {
+    "setVersionVariables": true
+  },
+  "versionHeightOffset": 1,
+  "buildNumberOffset": 1
+}


### PR DESCRIPTION
## Summary
- add Nerdbank.GitVersioning configuration via version.json and shared package reference
- ensure central package management tracks the Nerdbank.GitVersioning package
- update the build workflow to always pack the NuGet package, upload it as an artifact, and publish on main and tagged builds

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e55361f030832d833f4f6daad88ea1