### PR TITLE
Remove GitVersioning dependency to fix shallow clone builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
+    <!-- Static version information (fallback when Git metadata is unavailable) -->
+    <VersionPrefix>0.5.0</VersionPrefix>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <FileVersion>0.5.0.0</FileVersion>
+    <InformationalVersion>0.5.0</InformationalVersion>
+
     <!-- Assembly info -->
     <Product>MQ</Product>
     <Company>AzureStack Compute</Company>
@@ -35,10 +41,6 @@
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND '$(OS)' != 'Windows_NT'">
     <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageReference Include="coverlet.collector" />


### PR DESCRIPTION
## Summary
- remove the Nerdbank.GitVersioning package reference from the shared build props
- define static version metadata so builds succeed even when Git history is unavailable

## Testing
- dotnet build MessageQueue.sln *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e56f2586a0832db182538c41176686