### PR TITLE
Fix manual release workflow permissions

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -10,6 +10,9 @@ on:
         description: 'Optional release notes (Markdown).'
         required: false
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Build, package, and create release


### PR DESCRIPTION
## Summary
- grant the manual release workflow contents: write permission so softprops/action-gh-release can create releases

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e57d9f94ec832d8d75481809e637ea